### PR TITLE
Fix Ember 2.0 deprecation (broccoli-funnel replaces this.pickFiles)

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var mergeTrees = require('broccoli-merge-trees');
+var Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: 'ember-cli-pdf-js',
@@ -25,13 +26,13 @@ module.exports = {
       return tree;
     }
 
-    var pdfJsWorkerTree = this.pickFiles(this.app.bowerDirectory + '/pdfjs-dist/build',{
+    var pdfJsWorkerTree = new Funnel(this.app.bowerDirectory + '/pdfjs-dist/build',{
       srcDir: '/',
       files: ['pdf.worker.js'],
       destDir: 'assets/' + this.moduleName()
     });
 
-    var publicTree = this.pickFiles(tree, {
+    var publicTree = new Funnel(tree, {
       srcDir: '/',
       destDir: 'assets/' + this.moduleName()
     });

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "pdf"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.0.0",
+    "broccoli-funnel": "^0.2.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
To fix:

[Deprecated] this.pickFiles is deprecated, please use broccoli-funnel directly instead  [addon: ember-cli-pdf-js]
